### PR TITLE
使用 fofa.info 代替 fofa.so

### DIFF
--- a/module/finger/source/fofa.go
+++ b/module/finger/source/fofa.go
@@ -84,7 +84,7 @@ func GetConfig() Config {
 func fofa_api(keyword string, email string, key string, page int, size int) string {
 	input := []byte(keyword)
 	encodeString := base64.StdEncoding.EncodeToString(input)
-	api_request := fmt.Sprintf("https://fofa.so/api/v1/search/all?email=%s&page=%d&size=%d&key=%s&qbase64=%s&fields=ip,host,title,port,protocol", strings.Trim(email, " "), page, size, strings.Trim(key, " "), encodeString)
+	api_request := fmt.Sprintf("https://fofa.info/api/v1/search/all?email=%s&page=%d&size=%d&key=%s&qbase64=%s&fields=ip,host,title,port,protocol", strings.Trim(email, " "), page, size, strings.Trim(key, " "), encodeString)
 	return api_request
 }
 


### PR DESCRIPTION
EHole 使用的是 fofa.so 提供的 API，目前已经无法使用
<img width="651" alt="image" src="https://user-images.githubusercontent.com/70050083/162108409-9e3f1855-4efb-4688-bbd3-44615ff9b1a9.png">

发现无法解析 fofa.so 的地址

<img width="349" alt="截屏2022-04-07 10 29 48" src="https://user-images.githubusercontent.com/70050083/162108469-96726516-3f8f-475d-ac04-1c42f312a982.png">

看了一下源码，发现只需要将 fofa.so 改为 fofa.info 即可修复该问题，经测试使用

``` bash
./ehole fofaext -l ips.txt
```

没有问题

<img width="313" alt="截屏2022-04-07 10 31 21" src="https://user-images.githubusercontent.com/70050083/162108632-1c048428-8c04-4b15-bb10-3ebee9d237fc.png">


